### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,12 +5,12 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-18.04
+    container: docker://continuumio/miniconda3:4.7.12
     steps:
-    - uses: docker://continuumio/miniconda3:4.7.12
     - run: conda install -q -y -c conda-forge tectonic
-    - run: source $CONDA/bin/activate base && which tectonic
+    - run: which tectonic
     - uses: actions/checkout@v1
-    - run: source $CONDA/bin/activate base && cd tex && tectonic jupyterhub-evaluation-whitepaper.tex && cd ..
+    - run: cd tex && tectonic jupyterhub-evaluation-whitepaper.tex && cd ..
     - run: mkdir -p pdf_out/
     - run: mv tex/jupyterhub-evaluation-whitepaper.pdf pdf_out/.
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,12 +7,10 @@ jobs:
     runs-on: ubuntu-18.04
     container: docker://continuumio/miniconda3:4.7.12
     steps:
-    - run: conda install -q -y -c conda-forge tectonic
-    - run: which tectonic
+    - run: conda install -q -y -c conda-forge tectonic && which tectonic
     - uses: actions/checkout@v1
-    - run: cd tex && tectonic jupyterhub-evaluation-whitepaper.tex && cd ..
     - run: mkdir -p pdf_out/
-    - run: mv tex/jupyterhub-evaluation-whitepaper.pdf pdf_out/.
+    - run: tectonic tex/jupyterhub-evaluation-whitepaper.tex --outdir pdf_out/ --outfmt pdf
     - uses: actions/upload-artifact@v1
       with:
         name: jupyterhub-evaluation-whitepaper.pdf


### PR DESCRIPTION
There's a flaw in current `master`: Our way of "using" the miniconda container does not work, but as there's a miniconda installed in the standard runner, we don't notice. This PR fixes this by specifying that all of the job is meant to be run in the `container:`.