### PR TITLE
Trigger PDF builds only for master branch updates

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,9 @@
 name: Build PDF
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
This should solve the problem that the latest PDF build/artifact is not necessarily the latest approved (!) version of the document. "Work in progress" builds should be done locally now.